### PR TITLE
refactor: lock contracts version

### DIFF
--- a/contracts/eth/enums/ProtocolEnum.sol
+++ b/contracts/eth/enums/ProtocolEnum.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity 0.8.17;
 
 enum ProtocolEnum {
     Balancer,

--- a/contracts/eth/mock/Mock3CoinETHStrategy.sol
+++ b/contracts/eth/mock/Mock3CoinETHStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../strategies/ETHBaseStrategy.sol";
 import "../enums/ProtocolEnum.sol";

--- a/contracts/eth/mock/Mock3rdEthPool.sol
+++ b/contracts/eth/mock/Mock3rdEthPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";

--- a/contracts/eth/mock/MockETHVault.sol
+++ b/contracts/eth/mock/MockETHVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/mock/MockEthStrategy.sol
+++ b/contracts/eth/mock/MockEthStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../strategies/ETHBaseStrategy.sol";
 import "./Mock3rdEthPool.sol";

--- a/contracts/eth/oracle/IPriceOracleConsumer.sol
+++ b/contracts/eth/oracle/IPriceOracleConsumer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 /// @title IPriceOracleConsumer interface
 interface IPriceOracleConsumer {

--- a/contracts/eth/oracle/PriceOracleConsumer.sol
+++ b/contracts/eth/oracle/PriceOracleConsumer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./IPriceOracleConsumer.sol";

--- a/contracts/eth/strategies/ETHBaseClaimableStrategy.sol
+++ b/contracts/eth/strategies/ETHBaseClaimableStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "./ETHBaseStrategy.sol";
 

--- a/contracts/eth/strategies/ETHBaseStrategy.sol
+++ b/contracts/eth/strategies/ETHBaseStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/IETHStrategy.sol
+++ b/contracts/eth/strategies/IETHStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../vault/IETHVault.sol";
 

--- a/contracts/eth/strategies/aave/AaveWETHstETHStrategy.sol
+++ b/contracts/eth/strategies/aave/AaveWETHstETHStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/aura/AuraREthWEthStrategy.sol
+++ b/contracts/eth/strategies/aura/AuraREthWEthStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/aura/AuraWstETHWETHStrategy.sol
+++ b/contracts/eth/strategies/aura/AuraWstETHWETHStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/convex/ConvexSETHStrategy.sol
+++ b/contracts/eth/strategies/convex/ConvexSETHStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/convex/ConvexStETHStrategy.sol
+++ b/contracts/eth/strategies/convex/ConvexStETHStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/convex/ConvexrETHwstETHStrategy.sol
+++ b/contracts/eth/strategies/convex/ConvexrETHwstETHStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/convex/ETHConvexBaseStrategy.sol
+++ b/contracts/eth/strategies/convex/ETHConvexBaseStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "../ETHBaseClaimableStrategy.sol";
 import "../../../external/convex/IConvexReward.sol";

--- a/contracts/eth/strategies/dforce/ETHDForceRevolvingLoanStrategy.sol
+++ b/contracts/eth/strategies/dforce/ETHDForceRevolvingLoanStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/euler/ETHEulerRevolvingLoanStrategy.sol
+++ b/contracts/eth/strategies/euler/ETHEulerRevolvingLoanStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/stakewise/StakeWiseEthSeth23000Strategy.sol
+++ b/contracts/eth/strategies/stakewise/StakeWiseEthSeth23000Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../../external/uniswap/IUniswapV3.sol";

--- a/contracts/eth/strategies/stakewise/StakeWiseReth2Seth2500Strategy.sol
+++ b/contracts/eth/strategies/stakewise/StakeWiseReth2Seth2500Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../../external/uniswap/IUniswapV3.sol";

--- a/contracts/eth/strategies/uniswap-v2/ETHUniswapV2Strategy.sol
+++ b/contracts/eth/strategies/uniswap-v2/ETHUniswapV2Strategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/uniswapv3/ETHUniswapV3BaseStrategy.sol
+++ b/contracts/eth/strategies/uniswapv3/ETHUniswapV3BaseStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/strategies/uniswapv3/ETHUniswapV3Strategy.sol
+++ b/contracts/eth/strategies/uniswapv3/ETHUniswapV3Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "./ETHUniswapV3BaseStrategy.sol";
 

--- a/contracts/eth/strategies/yearn/v2/YearnV2Strategy.sol
+++ b/contracts/eth/strategies/yearn/v2/YearnV2Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/eth/vault/ETHVault.sol
+++ b/contracts/eth/vault/ETHVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "./ETHVaultStorage.sol";
 import "../strategies/IETHStrategy.sol";

--- a/contracts/eth/vault/ETHVaultAdmin.sol
+++ b/contracts/eth/vault/ETHVaultAdmin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "./ETHVaultStorage.sol";
 

--- a/contracts/eth/vault/ETHVaultStorage.sol
+++ b/contracts/eth/vault/ETHVaultStorage.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 import "boc-contract-core/contracts/access-control/AccessControlMixin.sol";
 import "boc-contract-core/contracts/library/IterableIntMap.sol";
 import "boc-contract-core/contracts/library/StableMath.sol";

--- a/contracts/eth/vault/IETHVault.sol
+++ b/contracts/eth/vault/IETHVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 pragma experimental ABIEncoderV2;
 
 import "boc-contract-core/contracts/exchanges/IExchangeAggregator.sol";

--- a/contracts/mock/MockPriceModel.sol
+++ b/contracts/mock/MockPriceModel.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../external/dforce/IDForcePriceModel.sol";
 import "../external/dforce/IDForcePriceOracle.sol";

--- a/contracts/test/TestAaveLendAction.sol
+++ b/contracts/test/TestAaveLendAction.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "boc-contract-core/contracts/library/NativeToken.sol";

--- a/contracts/usd/enums/ProtocolEnum.sol
+++ b/contracts/usd/enums/ProtocolEnum.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity 0.8.17;
 
 enum ProtocolEnum {
     Balancer,

--- a/contracts/usd/mock/IEREC20Mint.sol
+++ b/contracts/usd/mock/IEREC20Mint.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/MockAavePriceOracleConsumer.sol
+++ b/contracts/usd/mock/MockAavePriceOracleConsumer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../../external/aave/IPriceOracleGetter.sol";
 

--- a/contracts/usd/mock/MockPriceOracle.sol
+++ b/contracts/usd/mock/MockPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "../../external/cream/IPriceOracle.sol";
 

--- a/contracts/usd/mock/MockValueInterpreter.sol
+++ b/contracts/usd/mock/MockValueInterpreter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "boc-contract-core/contracts/library/NativeToken.sol";

--- a/contracts/usd/mock/MockVault.sol
+++ b/contracts/usd/mock/MockVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: SEE LICENSE IN LICENSE
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/mock/mint/IERC20_DAI.sol
+++ b/contracts/usd/mock/mint/IERC20_DAI.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_LUSD.sol
+++ b/contracts/usd/mock/mint/IERC20_LUSD.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_ROCKET_POOL_ETH.sol
+++ b/contracts/usd/mock/mint/IERC20_ROCKET_POOL_ETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_STETH.sol
+++ b/contracts/usd/mock/mint/IERC20_STETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_SUSD.sol
+++ b/contracts/usd/mock/mint/IERC20_SUSD.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_TUSD.sol
+++ b/contracts/usd/mock/mint/IERC20_TUSD.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_USDC.sol
+++ b/contracts/usd/mock/mint/IERC20_USDC.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_USDT.sol
+++ b/contracts/usd/mock/mint/IERC20_USDT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_WETH.sol
+++ b/contracts/usd/mock/mint/IERC20_WETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/mock/mint/IERC20_WSTETH.sol
+++ b/contracts/usd/mock/mint/IERC20_WSTETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 

--- a/contracts/usd/strategies/aave/AaveLendingStEthStrategy.sol
+++ b/contracts/usd/strategies/aave/AaveLendingStEthStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/aura/Aura3PoolStrategy.sol
+++ b/contracts/usd/strategies/aura/Aura3PoolStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/Convex3CrvStrategy.sol
+++ b/contracts/usd/strategies/convex/Convex3CrvStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ConvexAaveStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexAaveStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ConvexBaseStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexBaseStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "boc-contract-core/contracts/strategy/BaseClaimableStrategy.sol";
 

--- a/contracts/usd/strategies/convex/ConvexCompoundStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexCompoundStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ConvexPaxStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexPaxStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "./ConvexBaseStrategy.sol";
 import "../../../external/compound/ICToken.sol";

--- a/contracts/usd/strategies/convex/ConvexSaaveStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexSaaveStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ConvexSusdStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexSusdStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ConvexUsdtStrategy.sol
+++ b/contracts/usd/strategies/convex/ConvexUsdtStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ib-usdc/ConvexIBUsdcStrategy.sol
+++ b/contracts/usd/strategies/convex/ib-usdc/ConvexIBUsdcStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/ib/ConvexIBUsdtStrategy.sol
+++ b/contracts/usd/strategies/convex/ib/ConvexIBUsdtStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/convex/meta/ConvexMetaPoolStrategy.sol
+++ b/contracts/usd/strategies/convex/meta/ConvexMetaPoolStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/dforce/DForceLendStrategy.sol
+++ b/contracts/usd/strategies/dforce/DForceLendStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/dforce/DForceRevolvingLoanStrategy.sol
+++ b/contracts/usd/strategies/dforce/DForceRevolvingLoanStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/dodo/DodoStrategy.sol
+++ b/contracts/usd/strategies/dodo/DodoStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/dodo/DodoV1Strategy.sol
+++ b/contracts/usd/strategies/dodo/DodoV1Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/euler/EulerRevolvingLoanStrategy.sol
+++ b/contracts/usd/strategies/euler/EulerRevolvingLoanStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/stargate/StargateSingleStrategy.sol
+++ b/contracts/usd/strategies/stargate/StargateSingleStrategy.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "boc-contract-core/contracts/strategy/BaseClaimableStrategy.sol";

--- a/contracts/usd/strategies/sushi/kashi/stake/SushiKashiStakeStrategy.sol
+++ b/contracts/usd/strategies/sushi/kashi/stake/SushiKashiStakeStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/uniswapv3/UniswapV3Strategy.sol
+++ b/contracts/usd/strategies/uniswapv3/UniswapV3Strategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/usd/strategies/yearn/earn/YearnEarnStrategy.sol
+++ b/contracts/usd/strategies/yearn/earn/YearnEarnStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/contracts/utils/AssetHelpers.sol
+++ b/contracts/utils/AssetHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 // import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";

--- a/contracts/utils/HarvestHelper.sol
+++ b/contracts/utils/HarvestHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "boc-contract-core/contracts/access-control/AccessControlMixin.sol";
 import '../eth/strategies/IETHStrategy.sol';

--- a/contracts/utils/actions/AaveLendActionMixin.sol
+++ b/contracts/utils/actions/AaveLendActionMixin.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "boc-contract-core/contracts/library/NativeToken.sol";

--- a/contracts/utils/actions/DodoPoolActionsMixin.sol
+++ b/contracts/utils/actions/DodoPoolActionsMixin.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/contracts/utils/actions/DodoPoolV1ActionsMixin.sol
+++ b/contracts/utils/actions/DodoPoolV1ActionsMixin.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';

--- a/contracts/utils/actions/UniswapV2ActionsMixin.sol
+++ b/contracts/utils/actions/UniswapV2ActionsMixin.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import '../../external/uniswap/IUniswapV2Router2.sol';
 import '../AssetHelpers.sol';

--- a/contracts/utils/actions/UniswapV2LiquidityActionsMixin.sol
+++ b/contracts/utils/actions/UniswapV2LiquidityActionsMixin.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import '../../external/uniswap/IUniswapV2Router2.sol';
 import '../AssetHelpers.sol';

--- a/contracts/utils/actions/UniswapV3ActionsMixin.sol
+++ b/contracts/utils/actions/UniswapV3ActionsMixin.sol
@@ -7,7 +7,7 @@
     file that was distributed with this source code.
 */
 
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity 0.8.17;
 
 import "../../external/uniswap/IUniswapV3SwapRouter.sol";
 import "../AssetHelpers.sol";

--- a/contracts/utils/actions/UniswapV3LiquidityActionsMixin.sol
+++ b/contracts/utils/actions/UniswapV3LiquidityActionsMixin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -124,7 +124,7 @@ const config = {
 
         },
             {
-                version: '0.8.3',
+                version: '0.8.17',
                 settings: {
                     optimizer: {
                         details: {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@openzeppelin/contracts~v3": "npm:@openzeppelin/contracts@^3.4.2",
     "@openzeppelin/upgrades": "^2.8.0",
     "bignumber.js": "^9.0.1",
-    "boc-contract-core": "1.6.0-beta5",
+    "boc-contract-core": "1.6.0-beta6",
     "eslint-plugin-mocha": "^9.0.0",
     "piggy-finance-utils": "^1.0.63"
   },


### PR DESCRIPTION
# Description
lock the pragma version 0.8.17, 
exclud OneInchV4Adapter，ParaSwapV5Adapter，ExchangeHelpers，ParaSwapV5ActionsMixin，MockUniswapV3Router
# Ticket

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
